### PR TITLE
Adding more logs.

### DIFF
--- a/celery/app/base.py
+++ b/celery/app/base.py
@@ -459,7 +459,10 @@ class Celery(object):
             try:
                 task.__qualname__ = fun.__qualname__
             except AttributeError:
+                logger.error('_task_from_fun: AttributeError inside %s.', name)
+                print('_task_from_fun: AttributeError inside %s.' % name )
                 pass
+
             self._tasks[task.name] = task
             task.bind(self)  # connects task to this app
             add_autoretry_behaviour(task, **options)
@@ -475,6 +478,7 @@ class Celery(object):
             style task classes, you should not need to use this for
             new projects.
         """
+        logger.info('register_task: task-based class %s ', task)
         task = inspect.isclass(task) and task() or task
         if not task.name:
             task_cls = type(task)
@@ -498,6 +502,7 @@ class Celery(object):
         with self._finalize_mutex:
             if not self.finalized:
                 if auto and not self.autofinalize:
+                    logger.error('Contract breach: app not finalized')
                     raise RuntimeError('Contract breach: app not finalized')
                 self.finalized = True
                 _announce_app_finalized(self)

--- a/celery/app/registry.py
+++ b/celery/app/registry.py
@@ -9,8 +9,12 @@ from celery._state import get_current_app
 from celery.app.autoretry import add_autoretry_behaviour
 from celery.exceptions import InvalidTaskError, NotRegistered
 from celery.five import items
+from celery.utils.log import get_logger
+
 
 __all__ = ('TaskRegistry',)
+
+logger = get_logger(__name__)
 
 
 class TaskRegistry(dict):
@@ -28,12 +32,15 @@ class TaskRegistry(dict):
         instance. Name must be configured prior to registration.
         """
         if task.name is None:
+            logger.error('Registry: Task name is none %s', task.name)
             raise InvalidTaskError(
                 'Task class {0!r} must specify .name attribute'.format(
                     type(task).__name__))
+
         task = inspect.isclass(task) and task() or task
         add_autoretry_behaviour(task)
         self[task.name] = task
+        logger.info('Registry: Task name registered %s', task)
 
     def unregister(self, name):
         """Unregister task by name.
@@ -47,7 +54,9 @@ class TaskRegistry(dict):
         """
         try:
             self.pop(getattr(name, 'name', name))
-        except KeyError:
+            logger.info('Registry: Un-Register error %s', name)
+        except KeyError as e:
+            logger.error('Registry: Keyerror %r', e, exc_info=True)
             raise self.NotRegistered(name)
 
     # -- these methods are irrelevant now and will be removed in 4.0

--- a/celery/app/utils.py
+++ b/celery/app/utils.py
@@ -17,6 +17,7 @@ from celery.platforms import pyimplementation
 from celery.utils.collections import ConfigurationView
 from celery.utils.imports import import_from_cwd, qualname, symbol_by_name
 from celery.utils.text import pretty
+from celery.utils.log import get_logger
 
 from .defaults import (_OLD_DEFAULTS, _OLD_SETTING_KEYS, _TO_NEW_KEY,
                        _TO_OLD_KEY, DEFAULTS, SETTING_KEYS, find)
@@ -27,6 +28,8 @@ except ImportError:
     # TODO: Remove this when we drop Python 2.7 support
     from collections import Mapping
 
+
+logger = get_logger(__name__)
 
 __all__ = (
     'Settings', 'appstr', 'bugreport',
@@ -392,6 +395,8 @@ def find_app(app, symbol_by_name=symbol_by_name, imp=import_from_cwd):
                             symbol_by_name=symbol_by_name, imp=imp,
                         )
                     except ImportError:
+                        logger.error("ImportError: inside utils %s ", app)
+                        print("ImportError: inside utils %s " % app)
                         pass
                 for suspect in values(vars(sym)):
                     if isinstance(suspect, Celery):

--- a/celery/loaders/base.py
+++ b/celery/loaders/base.py
@@ -127,7 +127,10 @@ class BaseLoader(object):
         if isinstance(obj, string_t):
             try:
                 obj = self._smart_import(obj, imp=self.import_from_cwd)
+                logger.info('config_from_object: loaded successfully %s ', obj)
             except (ImportError, AttributeError):
+                logger.error('config_from_object: error appeared %s ', obj)
+
                 if silent:
                     return False
                 raise
@@ -144,14 +147,18 @@ class BaseLoader(object):
         # Not sure if path is just a module name or if it includes an
         # attribute name (e.g., ``os.path``, vs, ``os.path.abspath``).
         try:
+            logger.info('_smart_import: loaded successfully %s ', path)
             return imp(path)
         except ImportError:
             # Not a module name, so try module + attribute.
+            logger.error('_smart_import error appeared %s ', imp)
+            print('_smart_import error appeared %s.' % imp)
             return symbol_by_name(path, imp=imp)
 
     def _import_config_module(self, name):
         try:
             self.find_module(name)
+            logger.info('_import_config_module: loaded successfully %s ', name)
         except NotAPackage:
             if name.endswith('.py'):
                 reraise(NotAPackage, NotAPackage(CONFIG_WITH_SUFFIX.format(
@@ -222,6 +229,7 @@ class BaseLoader(object):
                 return DictAttribute(usercfg)
 
     def autodiscover_tasks(self, packages, related_name='tasks'):
+        logger.info('autodiscover_tasks: loaded successfully %s ', packages)
         self.task_modules.update(
             mod.__name__ for mod in autodiscover_tasks(packages or (),
                                                        related_name) if mod)

--- a/celery/task/base.py
+++ b/celery/task/base.py
@@ -14,12 +14,15 @@ from celery import current_app
 from celery.app.task import Context
 from celery.app.task import Task as BaseTask
 from celery.app.task import _reprtask
+from celery.utils.log import get_logger
 from celery.five import python_2_unicode_compatible, with_metaclass
 from celery.local import Proxy, class_property, reclassmethod
 from celery.schedules import maybe_schedule
 from celery.utils.log import get_task_logger
 
 __all__ = ('Context', 'Task', 'TaskType', 'PeriodicTask', 'task')
+
+logger = get_logger(__name__)
 
 #: list of methods that must be classmethods in the old API.
 _COMPAT_CLASSMETHODS = (
@@ -114,7 +117,9 @@ class TaskType(type):
         # name, so we always return the registered version.
         tasks = app._tasks
         if task_name not in tasks:
+            logger.info('TaskName not in tasks %s ', task_name)
             tasks.register(new(cls, name, bases, attrs))
+
         instance = tasks[task_name]
         instance.bind(app)
         return instance.__class__

--- a/celery/utils/imports.py
+++ b/celery/utils/imports.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from kombu.utils.imports import symbol_by_name
 
 from celery.five import reload
+from celery.utils.log import get_logger
 
 #: Billiard sets this when execv is enabled.
 #: We use it to find out the name of the original ``__main__``
@@ -23,6 +24,8 @@ __all__ = (
     'cwd_in_path', 'find_module', 'import_from_cwd',
     'reload_from_cwd', 'module_file', 'gen_task_name',
 )
+
+logger = get_logger(__name__)
 
 
 class NotAPackage(Exception):
@@ -79,22 +82,25 @@ def find_module(module, path=None, imp=None):
     with cwd_in_path():
         try:
             return imp(module)
-        except ImportError:
+        except ImportError as e:
             # Raise a more specific error if the problem is that one of the
             # dot-separated segments of the module name is not a package.
+            logger.error('FindModuleImportCWD Error: %r', e, exc_info=True)
             if '.' in module:
                 parts = module.split('.')
                 for i, part in enumerate(parts[:-1]):
                     package = '.'.join(parts[:i + 1])
                     try:
                         mpart = imp(package)
-                    except ImportError:
+                    except ImportError as e:
                         # Break out and re-raise the original ImportError
                         # instead.
+                        logger.error('FindModuleImportSplit Error: %r', e, exc_info=True)
                         break
                     try:
                         mpart.__path__
-                    except AttributeError:
+                    except AttributeError as e:
+                        logger.error('FindModuleImportAttribute Error: %r', e, exc_info=True)
                         raise NotAPackage(package)
             raise
 
@@ -130,9 +136,11 @@ def gen_task_name(app, name, module_name):
     module_name = module_name or '__main__'
     try:
         module = sys.modules[module_name]
+        logger.info('imports module %s', module)
     except KeyError:
         # Fix for manage.py shell_plus (Issue #366)
         module = None
+        logger.error('gen_task_name error %s', module)
 
     if module is not None:
         module_name = module.__name__
@@ -150,7 +158,8 @@ def gen_task_name(app, name, module_name):
 def load_extension_class_names(namespace):
     try:
         from pkg_resources import iter_entry_points
-    except ImportError:  # pragma: no cover
+    except ImportError as e:  # pragma: no cover
+        logger.error('load_extension_class_names error %r', e, exc_info=True)
         return
 
     for ep in iter_entry_points(namespace):

--- a/celery/worker/consumer/consumer.py
+++ b/celery/worker/consumer/consumer.py
@@ -561,9 +561,7 @@ class Consumer(object):
             try:
                 strategy = strategies[type_]
             except KeyError as exc:
-                logger.exception(
-                    "UnregisteredTaskException: " + str(strategies)
-                )
+                logger.error('UnregisteredTaskKeyError:  %r', exc, exc_info=True)
                 return on_unknown_task(None, message, exc)
             else:
                 try:
@@ -574,8 +572,10 @@ class Consumer(object):
                         callbacks,
                     )
                 except (InvalidTaskError, ContentDisallowed) as exc:
+                    logger.error('UnregisteredTaskInvalidError:  %r', exc, exc_info=True)
                     return on_invalid_task(payload, message, exc)
                 except DecodeError as exc:
+                    logger.error('UnregisteredTaskDecodeError:  %r', exc, exc_info=True)
                     return self.on_decode_error(message, exc)
 
         return on_task_received


### PR DESCRIPTION
Adding more logs.
Sandbox box in progress for further testing.


```
 <@task: cms.djangoapps.contentstore.tasks.CourseExportTask of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:43,459 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: cms.djangoapps.contentstore.tasks.CourseImportTask of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,199 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: cms.djangoapps.contentstore.tasks.update_library_index of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,209 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: lms.djangoapps.email_marketing.tasks.update_user_email of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,223 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: cms.djangoapps.contentstore.tasks.export_olx of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,227 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: openedx.core.djangoapps.programs.tasks.update_certificate_visible_date_on_course_update of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,239 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: cms.djangoapps.contentstore.tasks.import_olx of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,242 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2 of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,255 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: openedx.core.djangoapps.programs.tasks.award_program_certificates of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,260 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: lms.djangoapps.verify_student.tasks.send_verification_status_email of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,263 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: openedx.core.djangoapps.verified_track_content.tasks.sync_cohort_with_mode of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,276 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: cms.djangoapps.contentstore.tasks.rerun_course of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,280 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,295 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: openedx.core.djangoapps.programs.tasks.revoke_program_certificates of proj at 0x7fc101f0a3a0 (v2 compatible)>
/edx/var/log/supervisor/cms_high_1-stderr.log:2020-11-22 11:16:44,307 INFO 24457 [celery.app.registry] [user None] [ip None] registry.py:43 - Registry name registered <@task: student.send_activation_email of proj at 0x7fc101f0a3a0 (v2 compatible)>
```